### PR TITLE
Fix for Cargo pipes elements not being excluded from creative tank

### DIFF
--- a/erkle64.FreeStuff/Scripts/Patch.cs
+++ b/erkle64.FreeStuff/Scripts/Patch.cs
@@ -133,7 +133,7 @@ namespace FreeStuff
                         var baseElementRecipe = AssetManager.getAsset<CraftingRecipe>("_base_olumic_acid");
                         foreach (var element in ItemTemplateManager.getAllElementTemplates())
                         {
-                            if (element.Value.modIdentifier == "TransportDucts") continue;
+                            if (element.Value.modIdentifier == "TransportDucts" || element.Value.identifier.StartsWith("_duct")) continue;
                             AddCreativeElementRecipe(baseElementRecipe, element.Value);
                         }
 


### PR DESCRIPTION
Had to use identifier to exclude elements as modIdentifier did not work for some reason on elements